### PR TITLE
Remove Users

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,7 @@
 	],
 	"require": {
 		"php": "^7.3 || ^8.0",
-		"codeigniter4/authentication-implementation": "1.0",
-		"tatter/users": "^1.0"
+		"codeigniter4/authentication-implementation": "1.0"
 	},
 	"require-dev": {
 		"codeigniter4/codeigniter4": "dev-develop",


### PR DESCRIPTION
`v2.0.0` had a `Tatter\Users` dependency in error. This PR removes that for the next minor release.