### PR TITLE
Feature: Support array datatypes.

### DIFF
--- a/src/Entities/Setting.php
+++ b/src/Entities/Setting.php
@@ -30,4 +30,23 @@ class Setting extends Entity
 
 		parent::__construct($data);
 	}
+
+	/**
+	 * Ensures correct casts
+	 * for array datatypes.
+	 *
+	 * @param string $value
+	 */
+	protected function setContent(string $value)
+	{
+		// If the setting content is already encoded (i.e., a string) when
+		// writing or reading from the database, the 'set' cast must be skipped.
+		if(in_array($this->casts['content'], ['array', 'json-array']) && is_string($value))
+		{
+			$value = $this->castAs($value, 'content');
+		}
+
+		$this->attributes['content'] = $value;
+	}
+
 }

--- a/tests/EntityTest.php
+++ b/tests/EntityTest.php
@@ -23,6 +23,27 @@ final class EntityTest extends SettingsTestCase
 		$this->assertSame(12, $setting->content);
 	}
 
+	/**
+	 * Test setting content from an encoded array and
+	 * reading the array object from the same string.
+	 */
+	public function testArrayContentCastsToDatatype()
+	{
+		$setting = new Setting([
+			'datatype' => 'json-array',
+			'content'  => '{"firstIndex": ["firstValue"], "secondIndex": ["secondValue"]}',
+		]);
+
+		$expected = [
+			'firstIndex'=>'firstValue',
+			'secondIndex'=>'secondValue',
+		];
+
+		$this->assertSame($expected, $setting->content);
+	}
+
+
+
 	public function testFaked()
 	{
 		$setting = fake(SettingModel::class, null, false);


### PR DESCRIPTION
This PR additionally allows the use of the "array" and "json-array" casts for datatypes as defined in CI4's entity.
In the previous state, while it was possible do use these datatype with `Settings`, the casts would fail in two cases:
1. If an encoded string (datatype 'array' or 'json-array') is stored in the database and loaded into the entity, it will trigger the `set`-cast, thus encoding/serializing the already encoded string again.
2. When trying to write an encoded string into the database via the entity, this would also trigger the additional encoding. (This is a rather rare case, as databse writing is usually done through the `CLI`.) 

This PR skips the additional encoding if
- the datatype is 'array' or 'json-array' and
- the content is a string.
If an array object is passed to the entity, casting (encoding) will still be done.

For the simple 'json' datatype, I think additional checks would be needed to see if the string value is already valid JSON or not.