### PR TITLE
Clear session after update.

### DIFF
--- a/src/Models/SettingModel.php
+++ b/src/Models/SettingModel.php
@@ -63,6 +63,32 @@ class SettingModel extends Model
 	}
 
 	/**
+	 * Removes stored and changed values
+	 * from the current user's session.
+	 *
+	 * @return void
+	 */
+	public function clearSession($params)
+	{
+		['id' => $ids, 'data' => $data, 'result' => $result] = $params;
+
+		// No need to clear if the content was
+		// not changed or the update failed.
+		if ($result === false || !array_key_exists('content', $data))
+		{
+			return;
+		}
+
+		// Get the setting name
+		$session = session();
+		foreach ($ids as $settingId)
+		{
+			$setting = $this->find($settingId);
+			$session->remove('settings-' . $setting->name);
+		}
+	}
+
+	/**
 	 * Retrieves available Settings from the
 	 * store, cache, or database; skips the
 	 * summary field to improve performance.


### PR DESCRIPTION
When updating a template in the database via the Model/Entity, the cache and templates storage is clear by `clearTemplates`.
However, if the value of the changes `Setting `is already stored in the session of the current user, it will persist until `$ttl `is over.

While I don't think we can reset the changed `Setting` in the sessions of all active users, we can at least do it for the current user who submitted the changes.