### PR TITLE
Demonstrate failing array casts.

### DIFF
--- a/src/Entities/Setting.php
+++ b/src/Entities/Setting.php
@@ -19,6 +19,21 @@ class Setting extends Entity
 	];
 
 	/**
+	 * Sets the cast datatype for
+	 * the content field.
+	 *
+	 * @param string $datatype
+	 *
+	 * @return $this
+	 */
+	public function setContentCast(string $datatype = 'string')
+	{
+		$this->casts['content'] = $datatype;
+
+		return $this;
+	}
+
+	/**
 	 * Forces the content to cast
 	 * to its predefined datatype.
 	 *
@@ -26,7 +41,7 @@ class Setting extends Entity
 	 */
 	public function __construct(array $data = null)
 	{
-		$this->casts['content'] = $data['datatype'] ?? 'string';
+		$this->setContentCast($data['datatype'] ?? 'string');
 
 		parent::__construct($data);
 	}

--- a/src/Models/SettingModel.php
+++ b/src/Models/SettingModel.php
@@ -96,7 +96,7 @@ class SettingModel extends Model
 		self::$templates = [];
 		foreach ($templates as $template)
 		{
-			self::$templates[$template['name']] = new Setting($template);
+			self::$templates[$template['name']] = (new Setting())->setContentCast($template['datatype'])->setAttributes($template);
 		}
 
 		return self::$templates;

--- a/tests/EntityTest.php
+++ b/tests/EntityTest.php
@@ -25,7 +25,10 @@ final class EntityTest extends SettingsTestCase
 
 	public function testContentJsonCastsToDatatype()
 	{
-		$array = ['a' => 'Bananas', 'b' => 'Oranges'];
+		$array = [
+			'a' => 'Bananas',
+			'b' => 'Oranges',
+		];
 
 		$setting = new Setting([
 			'datatype' => 'json-array',
@@ -33,9 +36,9 @@ final class EntityTest extends SettingsTestCase
 		]);
 
 		$check = $this->getPrivateProperty($setting, 'attributes')['content'];
-		$this->assertEquals('{"a":"Bananas","b":"Oranges"}', $check);
+		$this->assertSame('{"a":"Bananas","b":"Oranges"}', $check);
 
-		$this->assertEquals($array, $setting->content);
+		$this->assertSame($array, $setting->content);
 	}
 
 	public function testFaked()

--- a/tests/EntityTest.php
+++ b/tests/EntityTest.php
@@ -23,6 +23,21 @@ final class EntityTest extends SettingsTestCase
 		$this->assertSame(12, $setting->content);
 	}
 
+	public function testContentJsonCastsToDatatype()
+	{
+		$array = ['a' => 'Bananas', 'b' => 'Oranges'];
+
+		$setting = new Setting([
+			'datatype' => 'json-array',
+			'content'  => $array,
+		]);
+
+		$check = $this->getPrivateProperty($setting, 'attributes')['content'];
+		$this->assertEquals('{"a":"Bananas","b":"Oranges"}', $check);
+
+		$this->assertEquals($array, $setting->content);
+	}
+
 	public function testFaked()
 	{
 		$setting = fake(SettingModel::class, null, false);

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -17,17 +17,21 @@ final class ModelTest extends SettingsTestCase
 			'protected' => 1,
 		]);
 
+		// Load templates from the database into the model
+		$model = model(SettingModel::class);
+		$model->getTemplates();
+
+		// The attibute of the entity should be encoded
+		$setting   = $this->getPrivateProperty($model, 'templates')['fruits'];
+		$attribute = $this->getPrivateProperty($setting, 'attributes')['content'];
+
+		$this->assertSame('{"a":"Bananas","b":"Oranges"}', $attribute);
+
+		// The value returned from the getter should be decoded
 		$array = [
 			'a' => 'Bananas',
 			'b' => 'Oranges',
 		];
-
-		$model = model(SettingModel::class);
-		$model->getTemplates();
-		$setting = $this->getPrivateProperty($model, 'templates')['fruits'];
-
-		$check = $this->getPrivateProperty($setting, 'attributes')['content'];
-		$this->assertEquals('{"a":"Bananas","b":"Oranges"}', $check);
 
 		$this->assertSame($array, config('Settings')->fruits);
 	}

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use Tatter\Settings\Entities\Setting;
+use Tatter\Settings\Models\SettingModel;
+use Tests\Support\SettingsTestCase;
+
+final class ModelTest extends SettingsTestCase
+{
+	public function testGetTemplatesDoesNotCastDatabaseValues()
+	{
+		// Insert using the model (e.g., admin dashboard)
+		model(SettingModel::class)->insert([
+			'name'      => 'fruits',
+			'datatype'  => 'json-array',
+			'summary'   => 'Yummy fruits',
+			'content'   => '{"a":"Bananas","b":"Oranges"}',
+			'protected' => 1,
+		]);
+
+		$array = [
+			'a' => 'Bananas',
+			'b' => 'Oranges',
+		];
+
+		$model = model(SettingModel::class);
+		$model->getTemplates();
+		$setting = $this->getPrivateProperty($model, 'templates')['fruits'];
+
+		$check = $this->getPrivateProperty($setting, 'attributes')['content'];
+		$this->assertEquals('{"a":"Bananas","b":"Oranges"}', $check);
+
+		$this->assertSame($array, config('Settings')->fruits);
+	}
+
+}


### PR DESCRIPTION
So I tried to demonstrate the issue opened in #21 in some new tests.

With these tests I looked over the whole process of storing and retrieving Settings.
While the CI4 entity is working well, if we have a json-endoced array stored in the database in a template, encoded string gets filled into the Setting entity here:
https://github.com/tattersoftware/codeigniter4-settings/blob/6d9125ce42b23f500d81e7d940c6ec445d8f5448/src/Models/SettingModel.php#L99
The CI4 entity then `fills` the passed data using the magic `_set` method of the entity and in this process encodes the json-string again.

~The core issue here is this, I think:~
~Because the `cast` value of `content` gets set before the `parent constructor` is called, the filling of the entity will apply these casts.~
~As far as I can tell now, this is also happening for all other datatypes, but it does not really matter, if an "integer-string" is double-casted to integer. I would hence think that calling the parent constructor first could be the proper solution here.
I will try to test that with the other PR.~

~If I understand the concept of `Entity` right, casting is intended to have all data stored in the entity in strings and then just cast them around if they're requested.~

If I am correct, the same should be happening for CI4's entity in general. In the CI4 `EntityTest`, casting seems to only be tested with "manually" filled Entities, not with entities loaded from the database and containing array/object casts.

PS: Sorry for the mess ...