### PR TITLE
Remove auth requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,16 @@
 		}
 	],
 	"require": {
-		"php": "^7.3 || ^8.0",
-		"codeigniter4/authentication-implementation": "1.0"
+		"php": "^7.3 || ^8.0"
 	},
 	"require-dev": {
+		"codeigniter4/authentication-implementation": "1.0",
 		"codeigniter4/codeigniter4": "dev-develop",
 		"myth/auth": "dev-develop",
 		"tatter/tools": "^1.8"
+	},
+	"suggest": {
+		"codeigniter4/authentication-implementation": "Allows for user setting overrides"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
Moves `codeigniter4/authentication-implementation` to suggestion to allow non-authenticated use of this library.

Fixes #24 